### PR TITLE
💄 ajustes no CircleAmountAnswered

### DIFF
--- a/src/components/Confirmation/AmountAnsweredCard.vue
+++ b/src/components/Confirmation/AmountAnsweredCard.vue
@@ -1,9 +1,5 @@
 <template>
-  <CircleAmountAnswered>
-    <div class='label'>Você respondeu</div>
-    <div class='number'>{{ answered }}</div>
-    <div class='label'>questões</div>
-  </CircleAmountAnswered>
+  <CircleAmountAnswered :answered="answered" />
 </template>
 
 <script>
@@ -27,12 +23,5 @@ export default {
 div {
   color: white;
   line-height: initial;
-}
-.label {
-  font-size: 24px;
-}
-.number {
-  font-family: 'Roboto-Bold';
-  font-size: 100px;
 }
 </style>

--- a/src/components/Confirmation/CircleAmountAnswered.vue
+++ b/src/components/Confirmation/CircleAmountAnswered.vue
@@ -1,12 +1,19 @@
 <template>
   <div class="circle">
-    <slot></slot>
+    <div class="label">Você respondeu</div>
+    <div class="number">{{ answered }}</div>
+    <div class="label">questões</div>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'CircleAmountAnswered'
+  name: 'CircleAmountAnswered',
+  props: {
+    answered: {
+      required: true
+    }
+  }
 }
 </script>
 
@@ -20,5 +27,12 @@ export default {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+.label {
+  font-size: 24px;
+}
+.number {
+  font-family: 'Roboto-Bold';
+  font-size: 100px;
 }
 </style>


### PR DESCRIPTION
# Ajustes na tela de Questões Respondidas

## Responsáveis

@ericsonmoreira 

## Linked Issue

Close #47 

## 📝 Descrição

Durante os testes do app, verificamos que o componente que mostra a quantidade de acertos de um quiz respondido está "desalinhado". O texto `Você respondeu` está colado com a borda do circulo e isso poderá causar uma certo desconforto para os usuários do `Qualiquiz`. Deveria estar conforma o que estabelece o design do [Figma](![image](https://user-images.githubusercontent.com/1212015/131731523-8c2c1285-6cc4-43ee-ae1d-e8c095c99ff8.png)).

## 🖥 Passos a passo para teste

Descrever_o_passo_a_passo_para_testar_o_pr

1. Acessar a página de `questões respondidas`
2. Verificar se o _component_ está de acordo com o layout do Figma 

## 📎 Observações

> 🚀 O _component_ que renderiza o círculo estava recebendo um conteúdo pelo `slot`. Achei mais lógico apenas receber a quantidade de questões acertadas como props e encapsular tudo dentro do _component_ `CircleAmountAnswered`.  

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
