### PR TITLE
Feature/i46 footer

### DIFF
--- a/src/components/Questions/QuestionsList.vue
+++ b/src/components/Questions/QuestionsList.vue
@@ -14,6 +14,7 @@
       />
     </div>
     <NavegationButton
+      id="navigation-button"
       :question-number="currentQuestion"
       @change-previous="changePrevious"
       @change-next="changeNext"
@@ -108,7 +109,11 @@ scoped>
 }
 #content-question{
   margin: 10px 0px;
-  padding: 16px 16px 16px 16px;
+  padding: 16px 16px 83px 16px;
 }
-
+#navigation-button{
+  width: 100vw;
+  position: fixed;
+  bottom: 0;
+}
 </style>

--- a/src/views/InitQuiz.vue
+++ b/src/views/InitQuiz.vue
@@ -1,15 +1,64 @@
 <template>
   <div>
+    <div v-show="showLoading">
+      <Loading />
+    </div>
     <h1>{{ getCurrentQuizId }}</h1>
+    <h1>{{this.getToken}}</h1>
+    <h1>teste</h1>
+    <div class="button">
+          <PurpleButton
+            @click="iniciarQuiz"
+            class="text-center"
+            label="INICIAR AVALIAÇÃO"
+          />
+        </div>
   </div>
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
+import PurpleButton from '../components/UX/PurpleButton.vue'
+import Loading from '../components/Loading.vue'
 export default {
   name: 'InitQuiz',
+  components: {
+    PurpleButton,
+    Loading
+  },
+  data () {
+    return {
+      showLoading: false
+    }
+  },
   computed: {
-    ...mapGetters('quiz', ['getCurrentQuizId'])
+    ...mapGetters('quiz', {
+      nameQuiz: 'getName',
+      timeLimit: 'getTimeLimit',
+      currentQuestion: 'getCurrentQuestion',
+      description: 'getDescription',
+      getCurrentQuizId: 'getCurrentQuizId'
+    }),
+    ...mapGetters('authentication', ['getToken']),
+    ...mapGetters('application', ['getDevelopment'])
+  },
+  methods: {
+    ...mapActions('quiz', ['initUserQuizzes', 'initQuiz']),
+    ...mapActions('clock', ['initClock']),
+    iniciarQuiz () {
+      this.showLoading = true
+      this.initClock(this.timeLimit)
+      setTimeout(() => {
+        this.$router.push({ name: 'Question' })
+      }, 4000)
+    }
+  },
+  mounted () {
+    this.initQuiz({
+      codQuiz: this.getCurrentQuestion,
+      devMode: this.getDevelopment,
+      auth: this.getToken
+    })
   }
 }
 </script>


### PR DESCRIPTION
# Ajuste do footer da avaliação

## Responsáveis

@Laysacunha 

## Linked Issue

Close #46 

## 📝 Descrição

Realizado ajuste no componente footer da avaliação para ficar fixo no bottom, assim como no design do figma.
Para acessar o quiz foi necessário configurar o início do quiz dentro da View InitQuiz. Esse acesso será utilizado numa tarefa próxima de criar tela de início do Quiz. Logo, essa alteração está inclusa nessa PR.

## 🖥 Passos a passo para teste

Descrever_o_passo_a_passo_para_testar_o_pr

1. Clicar em `INICIAR` no quiz escolhido na tela inicial ou em `REVISAR`
2. Clicar em `INICIAR AVALIAÇÃO`
3. Verificar footer fixo no bottom da página, inclusive em questões que ocupam mais que o espaço vertical disponível da tela.

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
