### PR TITLE
Criação do BottomNavigation

### DIFF
--- a/src/components/UX/BottomNavigation.vue
+++ b/src/components/UX/BottomNavigation.vue
@@ -20,7 +20,7 @@ import { mapActions, mapGetters } from 'vuex'
 import routerNames from '../../router/routerNames'
 
 export default {
-  itens: 'BottomNavigation',
+  name: 'BottomNavigation',
   data () {
     return {
       itens: [

--- a/src/components/UX/BottomNavigation.vue
+++ b/src/components/UX/BottomNavigation.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="container">
+    <router-link
+      class="bottom-navigation-action"
+      :class="classObject"
+      v-for="(item, index) in this.itens"
+      :key="index"
+      :to="item.to"
+    >
+      <b-icon :icon="item.icon" />
+      <span>
+        {{ item.label }}
+      </span>
+    </router-link>
+  </div>
+</template>
+
+<script>
+import routerNames from '../../router/routerNames'
+
+export default {
+  itens: 'BottomNavigation',
+  data () {
+    return {
+      itens: [
+        { label: 'Início', icon: 'house-door-fill', to: routerNames.home },
+        { label: 'Avaliações', icon: 'receipt', to: routerNames.quizzes }
+      ],
+      classObject: {
+        active: true
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.container {
+  display: flex;
+  height: 72px;
+  width: 100%;
+  background: #ffffff;
+  box-shadow: 0px 0.5px 5px rgba(0, 0, 0, 0.039),
+    0px 3.75px 11px rgba(0, 0, 0, 0.19);
+}
+
+.bottom-navigation-action {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  span {
+    font-family: Roboto;
+    font-style: normal;
+    font-weight: normal;
+    font-size: 12px;
+    line-height: 16px;
+    letter-spacing: 0.5px;
+  }
+
+  svg {
+    margin-bottom: 4px;
+    height: 18px;
+    width: 18px;
+  }
+}
+
+.active {
+  color: $purple;
+}
+</style>

--- a/src/components/UX/BottomNavigation.vue
+++ b/src/components/UX/BottomNavigation.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container">
+  <div class="bottom-navigation">
     <div
       class="bottom-navigation-action"
       :class="item.id === actionSelected ? 'active' : ''"
@@ -56,7 +56,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.container {
+.bottom-navigation {
   display: flex;
   height: 72px;
   width: 100%;

--- a/src/components/UX/BottomNavigation.vue
+++ b/src/components/UX/BottomNavigation.vue
@@ -2,7 +2,7 @@
   <div class="container">
     <router-link
       class="bottom-navigation-action"
-      :class="classObject"
+      :class="item.id === selected ? 'active' : ''"
       v-for="(item, index) in this.itens"
       :key="index"
       :to="item.to"
@@ -16,6 +16,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import routerNames from '../../router/routerNames'
 
 export default {
@@ -23,13 +24,25 @@ export default {
   data () {
     return {
       itens: [
-        { label: 'Início', icon: 'house-door-fill', to: routerNames.home },
-        { label: 'Avaliações', icon: 'receipt', to: routerNames.quizzes }
-      ],
-      classObject: {
-        active: true
-      }
+        {
+          id: 'home',
+          label: 'Início',
+          icon: 'house-door-fill',
+          to: routerNames.home
+        },
+        {
+          id: 'quizzes',
+          label: 'Avaliações',
+          icon: 'receipt',
+          to: routerNames.quizzes
+        }
+      ]
     }
+  },
+  computed: {
+    ...mapGetters('bottomNavigation', {
+      selected: 'getActionSelected'
+    })
   }
 }
 </script>
@@ -50,6 +63,8 @@ export default {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  color: rgba(0, 0, 0, 0.6);
 
   span {
     font-family: Roboto;

--- a/src/components/UX/BottomNavigation.vue
+++ b/src/components/UX/BottomNavigation.vue
@@ -1,22 +1,22 @@
 <template>
   <div class="container">
-    <router-link
+    <div
       class="bottom-navigation-action"
-      :class="item.id === selected ? 'active' : ''"
+      :class="item.id === actionSelected ? 'active' : ''"
       v-for="(item, index) in this.itens"
       :key="index"
-      :to="item.to"
+      @click="handleClickAction(item)"
     >
       <b-icon :icon="item.icon" />
       <span>
         {{ item.label }}
       </span>
-    </router-link>
+    </div>
   </div>
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 import routerNames from '../../router/routerNames'
 
 export default {
@@ -41,8 +41,16 @@ export default {
   },
   computed: {
     ...mapGetters('bottomNavigation', {
-      selected: 'getActionSelected'
+      actionSelected: 'getActionSelected'
     })
+  },
+  methods: {
+    ...mapActions('bottomNavigation', ['setActionSelected']),
+    handleClickAction (item) {
+      if (this.actionSelected !== item.id) {
+        this.$router.push(item.to)
+      }
+    }
   }
 }
 </script>

--- a/src/components/UX/ListingCardsHorizontal.vue
+++ b/src/components/UX/ListingCardsHorizontal.vue
@@ -6,7 +6,7 @@
           <CardAvaliacoes
             :id="avaliacao.id"
             :titulo="avaliacao.titulo"
-          :acertos="Number(avaliacao.acertos)"
+            :acertos="Number(avaliacao.acertos)"
             :concluida="avaliacao.respondido"
             :dataCriacao="new Date(avaliacao.data_criacao)"
           />
@@ -15,8 +15,7 @@
     </div>
     <div v-else class="not-content-wrapper">
       <NotContentCard
-        message="Você ainda não possui novas avaliações.
-Aguarde que logo estará disponível!"
+        :message="notContentMesage"
       />
     </div>
   </div>
@@ -34,6 +33,10 @@ export default {
       type: Array,
       required: true,
       default: () => []
+    },
+    notContentMesage: {
+      type: String,
+      required: true
     }
   }
 }

--- a/src/components/UX/ListingCardsVertical.vue
+++ b/src/components/UX/ListingCardsVertical.vue
@@ -13,8 +13,7 @@
     </div>
     <div v-else class="not-content-wrapper">
       <NotContentCard
-        message="Você ainda não possui avaliações concluídas.
-Responda a sua prmeira avaliação!"
+        :message="notContentMesage"
       />
     </div>
   </div>
@@ -30,6 +29,10 @@ export default {
       type: Array,
       required: true,
       default: () => []
+    },
+    notContentMesage: {
+      type: String,
+      required: true
     }
   },
   components: { CardAvaliacoes, NotContentCard },

--- a/src/components/layouts/BottomNavigationContainer.vue
+++ b/src/components/layouts/BottomNavigationContainer.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="bottom-navigation-container">
+    <BottomNavigation class="bottom-navigation" />
+    <div class="wrapper">
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+import BottomNavigation from '../UX/BottomNavigation'
+export default {
+  name: 'BottomNavigationContainer',
+  props: {
+    selected: {
+      type: String,
+      required: true
+    }
+  },
+  components: { BottomNavigation },
+  methods: {
+    ...mapActions('bottomNavigation', ['setActionSelected'])
+  },
+  mounted () {
+    this.setActionSelected(this.selected)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.bottom-navigation-container {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+}
+
+.bottom-navigation {
+  position: fixed;
+  bottom: 0;
+  z-index: 9999;
+}
+
+.wrapper {
+  overflow-y: auto;
+  padding-bottom: 72px;
+}
+</style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,6 +5,7 @@ import authentication from './modules/authentication'
 import quiz from './modules/quiz'
 import application from './modules/application'
 import feedback from './modules/feedback'
+// import bottomNavigation from './modules/bottomNavigation'
 
 import VuePersist from 'vuex-persist'
 
@@ -23,6 +24,7 @@ export default new Vuex.Store({
     quiz,
     application,
     feedback
+    // bottomNavigation
   },
   state: {},
   mutations: {},

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,7 @@ import authentication from './modules/authentication'
 import quiz from './modules/quiz'
 import application from './modules/application'
 import feedback from './modules/feedback'
-// import bottomNavigation from './modules/bottomNavigation'
+import bottomNavigation from './modules/bottomNavigation'
 
 import VuePersist from 'vuex-persist'
 
@@ -23,8 +23,8 @@ export default new Vuex.Store({
     authentication,
     quiz,
     application,
-    feedback
-    // bottomNavigation
+    feedback,
+    bottomNavigation
   },
   state: {},
   mutations: {},

--- a/src/store/modules/bottomNavigation.js
+++ b/src/store/modules/bottomNavigation.js
@@ -1,0 +1,19 @@
+export default {
+  namespaced: true,
+  state: {
+    actionSelected: ''
+  },
+  getters: {
+    getActionSelected: state => state.actionSelected
+  },
+  mutations: {
+    SET_ACTION_SELECTED: (state, action) => {
+      state.actionSelected = action
+    }
+  },
+  actions: {
+    setActionSelected: ({ commit }, action) => {
+      commit('SET_ACTION_SELECTED', action)
+    }
+  }
+}

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -12,7 +12,7 @@
       <b-tab active>
         <template #title>
           <div class="tab">
-            <b-icon-exclamation-triangle class="mb-1" font-scale="1.5" />
+            <b-icon-exclamation-triangle-fill class="mb-1" font-scale="1.5" />
             <span>Novas</span>
           </div>
         </template>

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -12,7 +12,7 @@
     >
       <b-tab active>
         <template #title>
-          <div class="title">
+          <div class="tab">
             <b-icon-exclamation-triangle class="mb-1" font-scale="1.5" />
             <span>Novas</span>
           </div>
@@ -21,7 +21,7 @@
       </b-tab>
       <b-tab>
         <template #title>
-          <div class="title">
+          <div class="tab">
             <b-icon-check-circle-fill class="mb-1" font-scale="1.5" />
             <span>Concluídas</span>
           </div>
@@ -88,7 +88,7 @@ export default {
   overflow: hidden;
 }
 
-.title {
+.tab {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -107,7 +107,7 @@ export default {
 .active-nav-item {
   position: relative;
 
-  .title {
+  .tab {
     color: #ffffff;
   }
 

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -19,6 +19,8 @@
         <ListingCardsVertical
           :data="userQuizzesDisponiveis"
           :class="userQuizzesDisponiveis.length <= 0 ? 'not-content' : ''"
+          notContentMesage="Você ainda não possui novas avaliações.
+Aguarde que logo estará disponível!"
         />
       </b-tab>
       <b-tab>
@@ -31,6 +33,8 @@
         <ListingCardsVertical
           :data="userQuizzesConcluidas"
           :class="userQuizzesConcluidas.length <= 0 ? 'not-content' : ''"
+          notContentMesage="Você ainda não possui avaliações concluídas.
+Responda a sua prmeira avaliação!"
         />
       </b-tab>
     </b-tabs>

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -62,6 +62,7 @@ export default {
   margin-top: 16px;
   display: flex;
   flex-direction: column;
+  padding-top: 80px;
 }
 
 .not-content {
@@ -74,6 +75,9 @@ export default {
 }
 
 .nav-wrapper {
+  top: 0;
+  width: 100%;
+  position: fixed;
   background-color: $purple;
   box-shadow: 0px 0.5px 1.75px rgba(0, 0, 0, 0.039),
     0px 1.85px 6.25px rgba(0, 0, 0, 0.19);

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -1,26 +1,7 @@
 <template>
   <div>
-    <!-- TODO: passar isso para um component -->
-    <b-tabs fill justified no-nav-style content-class="teste">
-      <b-tab active>
-        <template #title>
-          <div class="title">
-            <b-icon-exclamation-triangle />
-            <span>Novas</span>
-          </div>
-        </template>
-        <p>{{ AllQuizzes }}</p>
-      </b-tab>
-      <b-tab title="Concluídas">
-        <template #title>
-          <div class="title">
-            <b-icon-check-circle-fill />
-            <span>Concluídas</span>
-          </div>
-        </template>
-        <p>{{ getUserQuizzes }}</p>
-      </b-tab>
-    </b-tabs>
+    <h1>{{ AllQuizzes }}</h1>
+    <h2>{{ getUserQuizzes }}</h2>
   </div>
 </template>
 
@@ -34,16 +15,4 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
-.teste {
-  background-color: red;
-}
-
-.title {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 80px;
-}
-</style>
+<style lang="scss" scoped></style>

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -16,7 +16,10 @@
             <span>Novas</span>
           </div>
         </template>
-        <ListingCardsVertical :data="userQuizzesDisponiveis" />
+        <ListingCardsVertical
+          :data="userQuizzesDisponiveis"
+          :class="userQuizzesDisponiveis.length <= 0 ? 'not-content' : ''"
+        />
       </b-tab>
       <b-tab>
         <template #title>
@@ -25,7 +28,10 @@
             <span>Concluídas</span>
           </div>
         </template>
-        <ListingCardsVertical :data="userQuizzesConcluidas" />
+        <ListingCardsVertical
+          :data="userQuizzesConcluidas"
+          :class="userQuizzesConcluidas.length <= 0 ? 'not-content' : ''"
+        />
       </b-tab>
     </b-tabs>
   </BottomNavigation>
@@ -58,14 +64,13 @@ export default {
   flex-direction: column;
 }
 
-/* Tive que fazer isso para ajustar no centro. */
-.not-content-wrapper {
+.not-content {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   width: auto;
-  height: calc(100vh - 250px);
+  height: calc(100vh - 168px);
 }
 
 .nav-wrapper {

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -1,6 +1,5 @@
 <template>
-  <div>
-    <BottomNavigation />
+  <BottomNavigation selected="quizzes">
     <b-tabs
       fill
       justified
@@ -29,13 +28,13 @@
         <ListingCardsVertical :data="userQuizzesConcluidas" />
       </b-tab>
     </b-tabs>
-  </div>
+  </BottomNavigation>
 </template>
 
 <script>
-import { mapActions, mapGetters } from 'vuex'
+import { mapGetters } from 'vuex'
 import ListingCardsVertical from '../components/UX/ListingCardsVertical'
-import BottomNavigation from '../components/UX/BottomNavigation'
+import BottomNavigation from '../components/layouts/BottomNavigationContainer.vue'
 
 export default {
   name: 'AllQuizzes',
@@ -48,22 +47,11 @@ export default {
       userQuizzesDisponiveis: 'getUserQuizzesDisponiveis',
       userQuizzesConcluidas: 'getUserQuizzesConcluidas'
     })
-  },
-  methods: {
-    ...mapActions('bottomNavigation', ['setActionSelected'])
-  },
-  mounted () {
-    this.setActionSelected('quizzes')
   }
 }
 </script>
 
 <style lang="scss">
-.tabs {
-  height: 100vh;
-  padding-bottom: 72px;
-}
-
 .content {
   margin-top: 16px;
   display: flex;

--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <BottomNavigation />
     <b-tabs
       fill
       justified
@@ -32,19 +33,27 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 import ListingCardsVertical from '../components/UX/ListingCardsVertical'
+import BottomNavigation from '../components/UX/BottomNavigation'
 
 export default {
   name: 'AllQuizzes',
   components: {
-    ListingCardsVertical
+    ListingCardsVertical,
+    BottomNavigation
   },
   computed: {
     ...mapGetters('quiz', {
       userQuizzesDisponiveis: 'getUserQuizzesDisponiveis',
       userQuizzesConcluidas: 'getUserQuizzesConcluidas'
     })
+  },
+  methods: {
+    ...mapActions('bottomNavigation', ['setActionSelected'])
+  },
+  mounted () {
+    this.setActionSelected('quizzes')
   }
 }
 </script>

--- a/src/views/InitQuiz.vue
+++ b/src/views/InitQuiz.vue
@@ -4,15 +4,15 @@
       <Loading />
     </div>
     <h1>{{ getCurrentQuizId }}</h1>
-    <h1>{{this.getToken}}</h1>
+    <h1>{{ this.getToken }}</h1>
     <h1>teste</h1>
     <div class="button">
-          <PurpleButton
-            @click="iniciarQuiz"
-            class="text-center"
-            label="INICIAR AVALIAÇÃO"
-          />
-        </div>
+      <PurpleButton
+        @click="iniciarQuiz"
+        class="text-center"
+        label="INICIAR AVALIAÇÃO"
+      />
+    </div>
   </div>
 </template>
 

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -10,7 +10,11 @@
           <h1 class="label-title roboto-bold">Avaliações disponíveis</h1>
         </div>
         <div class="wrapper-horizontal-list">
-          <ListingCardsHorizontal :data="userQuizzesDisponiveis" />
+          <ListingCardsHorizontal
+            :data="userQuizzesDisponiveis"
+            notContentMesage="Você ainda não possui novas avaliações.
+Aguarde que logo estará disponível!"
+          />
         </div>
         <div class="wrapper-button">
           <b-button
@@ -25,7 +29,11 @@
           <h1 class="label-title roboto-bold">Avaliações concluídas</h1>
         </div>
         <div class="wrapper-vertical-list">
-          <ListingCardsVertical :data="userQuizzesConcluidas" />
+          <ListingCardsVertical
+            :data="userQuizzesConcluidas"
+            notContentMesage="Você ainda não possui avaliações concluídas.
+Responda a sua prmeira avaliação!"
+          />
         </div>
       </b-container>
     </div>
@@ -53,7 +61,8 @@ export default {
   data () {
     return {
       showLoading: false,
-      img: require('../assets/images/blank.png')
+      img: require('../assets/images/blank.png'),
+      notContentMesage: ''
     }
   },
   computed: {

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -71,6 +71,7 @@ export default {
   methods: {
     ...mapActions('clock', ['initClock']),
     ...mapActions('quiz', ['initUserQuizzes']),
+    ...mapActions('bottomNavigation', ['setActionSelected']),
     iniciarQuiz () {
       this.showLoading = true
       this.initClock(this.timeLimit)
@@ -92,6 +93,8 @@ export default {
       },
       spaceBetween: -35
     })
+
+    this.setActionSelected('home')
   }
 }
 </script>

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -5,6 +5,7 @@
     </div>
     <div class="position-absolute background" v-show="!showLoading">
       <HeaderLogo />
+      <BottomNavigation />
       <b-container class="content">
         <div class="title">
           <h1 class="label-title roboto-bold">Avaliações disponíveis</h1>
@@ -40,13 +41,15 @@ import HeaderLogo from '../components/HeaderLogo.vue'
 import ListingCardsHorizontal from '../components/UX/ListingCardsHorizontal'
 import ListingCardsVertical from '../components/UX/ListingCardsVertical'
 import routerNames from '../router/routerNames'
+import BottomNavigation from '../components/UX/BottomNavigation.vue'
 
 export default {
   components: {
     Loading,
     HeaderLogo,
     ListingCardsHorizontal,
-    ListingCardsVertical
+    ListingCardsVertical,
+    BottomNavigation
   },
   data () {
     return {

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -70,7 +70,6 @@ export default {
   methods: {
     ...mapActions('clock', ['initClock']),
     ...mapActions('quiz', ['initUserQuizzes']),
-    ...mapActions('bottomNavigation', ['setActionSelected']),
     iniciarQuiz () {
       this.showLoading = true
       this.initClock(this.timeLimit)
@@ -92,8 +91,6 @@ export default {
       },
       spaceBetween: -35
     })
-
-    this.setActionSelected('home')
   }
 }
 </script>

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -1,11 +1,10 @@
 <template>
-  <div>
+  <BottomNavigationContainer selected="home">
     <div v-show="showLoading">
       <Loading></Loading>
     </div>
-    <div class="position-absolute background" v-show="!showLoading">
+    <div class="background" v-show="!showLoading">
       <HeaderLogo />
-      <BottomNavigation />
       <b-container class="content">
         <div class="title">
           <h1 class="label-title roboto-bold">Avaliações disponíveis</h1>
@@ -30,7 +29,7 @@
         </div>
       </b-container>
     </div>
-  </div>
+  </BottomNavigationContainer>
 </template>
 
 <script>
@@ -41,7 +40,7 @@ import HeaderLogo from '../components/HeaderLogo.vue'
 import ListingCardsHorizontal from '../components/UX/ListingCardsHorizontal'
 import ListingCardsVertical from '../components/UX/ListingCardsVertical'
 import routerNames from '../router/routerNames'
-import BottomNavigation from '../components/UX/BottomNavigation.vue'
+import BottomNavigationContainer from '../components/layouts/BottomNavigationContainer'
 
 export default {
   components: {
@@ -49,7 +48,7 @@ export default {
     HeaderLogo,
     ListingCardsHorizontal,
     ListingCardsVertical,
-    BottomNavigation
+    BottomNavigationContainer
   },
   data () {
     return {


### PR DESCRIPTION
# Criação do BottomNavigation

## Responsáveis

@ericsonmoreira 

## Linked Issue

Close #59 

## 📝 Descrição

Uma das melhorias propostas pela equipe de `design` foi a adição de um menu de navegação inferior em as telas do `Qualiquiz`. Atualmente temos apenas duas opções, mas o componente que for criado deverá poder ser configurado para que se possa adicionar mais opções.

## 🖥 Passos a passo para teste

1. Acessar a página inicial do `Qualiquiz`
2. Clicar nas opções do `BottomNavigation`
3. Verificar se está redirecionando para as telas corretas
4. Verificar se está de acordo com o Figma

## 📎 Observações

> 🚀 Alguns ajustes na tela `Home` foram feitas nessa PR. Vide _issue_ #44

> 🚀 Foi criado o componente `BottomNavigationContainer` para encapsular a lógica do `BottomNavigation`

```vue
<BottomNavigationContainer selected="home">
  <!-- conteúdo aqui -->   
</BottomNavigationContainer>
```
- selected: id usado para referenciar qual a opção selecionada

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
