### PR TITLE
🔥 #65 - remove loading da tela inicial

### DIFF
--- a/src/views/IsusLogin/IsusLogin.vue
+++ b/src/views/IsusLogin/IsusLogin.vue
@@ -1,16 +1,12 @@
 <template>
-  <Loading />
+  <div></div>
 </template>
 
 <script>
-import Loading from '../../components/Loading.vue'
 import { mapActions } from 'vuex'
 
 export default {
   name: 'IsusLogin',
-  components: {
-    Loading
-  },
   methods: {
     ...mapActions('authentication', ['setToken']),
     ...mapActions('quiz', ['setId', 'cleanQuiz', 'initUserQuizzes']),

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -1,9 +1,6 @@
 <template>
   <BottomNavigationContainer selected="home">
-    <div v-show="showLoading">
-      <Loading></Loading>
-    </div>
-    <div class="background" v-show="!showLoading">
+    <div class="background">
       <HeaderLogo />
       <b-container class="content">
         <div class="title">
@@ -13,7 +10,7 @@
           <ListingCardsHorizontal
             :data="userQuizzesDisponiveis"
             notContentMesage="Você ainda não possui novas avaliações.
-Aguarde que logo estará disponível!"
+            Aguarde que logo estará disponível!"
           />
         </div>
         <div class="wrapper-button">
@@ -32,7 +29,7 @@ Aguarde que logo estará disponível!"
           <ListingCardsVertical
             :data="userQuizzesConcluidas"
             notContentMesage="Você ainda não possui avaliações concluídas.
-Responda a sua prmeira avaliação!"
+            Responda a sua prmeira avaliação!"
           />
         </div>
       </b-container>
@@ -43,7 +40,6 @@ Responda a sua prmeira avaliação!"
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import Swiper from 'swiper'
-import Loading from '../components/Loading'
 import HeaderLogo from '../components/HeaderLogo.vue'
 import ListingCardsHorizontal from '../components/UX/ListingCardsHorizontal'
 import ListingCardsVertical from '../components/UX/ListingCardsVertical'
@@ -52,7 +48,6 @@ import BottomNavigationContainer from '../components/layouts/BottomNavigationCon
 
 export default {
   components: {
-    Loading,
     HeaderLogo,
     ListingCardsHorizontal,
     ListingCardsVertical,
@@ -60,8 +55,6 @@ export default {
   },
   data () {
     return {
-      showLoading: false,
-      img: require('../assets/images/blank.png'),
       notContentMesage: ''
     }
   },


### PR DESCRIPTION
# Remove loading da tele inicial

## Responsáveis

@Laysacunha 

## Linked Issue

Close #65 

## 📝 Descrição

De acordo com figma o `Loading` existe apenas ao inciar um quiz, entretanto estava acontecendo também ao iniciar a aplicação. Foi verificado que isso ocorria porque a tela inicial passa por uma rota de consulta a API - view `Isus Login`. Nesta havia apenas o componente `Loading` no corpo do template. Para remove-lo foi necessário adicionar uma div, já que o template no Vuejs necessita de ao menos um elemento filho.

## 🖥 Passos a passo para teste

1. Iniciar projeto e verificar que o loading não aparece.
2. Navegar no menu inferior e observar que o loading não aparecer ao clicar em `Início`

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
