### PR TITLE
Ajustes na tela `Home`

### DIFF
--- a/src/components/Home/CardAvaliacoes.vue
+++ b/src/components/Home/CardAvaliacoes.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="card-avaliacao">
-    <span class="titulo-avaliacao roboto-bold">{{ titulo }}</span>
+    <span class="titulo-avaliacao roboto-bold">
+      {{ titulo }}
+    </span>
     <h4 class="data-criacao">{{ dataCriacaoFormated }}</h4>
     <progresso-acertos
       class="barra-progresso"
@@ -84,6 +86,12 @@ export default {
   line-height: 20px;
   letter-spacing: 0.1px;
   margin-bottom: 8px;
+  height: 40px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .data-criacao {

--- a/src/components/Home/CardAvaliacoes.vue
+++ b/src/components/Home/CardAvaliacoes.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="card-avaliacao">
-    <div class="titulo-avaliacao roboto-bold">{{ titulo }}</div>
+    <span class="titulo-avaliacao roboto-bold">{{ titulo }}</span>
     <h4 class="data-criacao">{{ dataCriacaoFormated }}</h4>
     <progresso-acertos
       class="barra-progresso"
@@ -84,10 +84,6 @@ export default {
   line-height: 20px;
   letter-spacing: 0.1px;
   margin-bottom: 8px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  max-width: 150px;
 }
 
 .data-criacao {

--- a/src/components/UX/ListingCardsHorizontal.vue
+++ b/src/components/UX/ListingCardsHorizontal.vue
@@ -11,7 +11,7 @@
         />
       </div>
     </div>
-    <div v-else class="not-content-wrapper">
+    <div v-else class="not-content-wrapper mt-4 mb-4">
       <NotContentCard :message="notContentMesage" />
     </div>
   </div>

--- a/src/components/UX/ListingCardsHorizontal.vue
+++ b/src/components/UX/ListingCardsHorizontal.vue
@@ -1,22 +1,18 @@
 <template>
-  <div class="container">
-    <div v-if="data.length > 0">
-      <div v-for="(avaliacao, index) in data" :key="index">
-        <div class="wrapper-card">
-          <CardAvaliacoes
-            :id="avaliacao.id"
-            :titulo="avaliacao.titulo"
-            :acertos="Number(avaliacao.acertos)"
-            :concluida="avaliacao.respondido"
-            :dataCriacao="new Date(avaliacao.data_criacao)"
-          />
-        </div>
+  <div class="listing-cards-horizontal">
+    <div v-if="data.length > 0" class="horizontal-section">
+      <div class="wrapper-card" v-for="(avaliacao, index) in data" :key="index">
+        <CardAvaliacoes
+          :id="avaliacao.id"
+          :titulo="avaliacao.titulo"
+          :acertos="Number(avaliacao.acertos)"
+          :concluida="avaliacao.respondido"
+          :dataCriacao="new Date(avaliacao.data_criacao)"
+        />
       </div>
     </div>
     <div v-else class="not-content-wrapper">
-      <NotContentCard
-        :message="notContentMesage"
-      />
+      <NotContentCard :message="notContentMesage" />
     </div>
   </div>
 </template>
@@ -43,22 +39,30 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.container {
+.listing-cards-horizontal {
   display: flex;
-  align-items: stretch;
-  overflow-x: scroll;
-  padding: 16px 16px 30px;
+  width: 100%;
 }
 
-::-webkit-scrollbar {
-  display: none;
+.horizontal-section {
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory;
+  display: flex;
+  width: 100%;
+  grid-auto-flow: column;
+  gap: 12px;
+  padding: 16px 16px 30px;
+  scroll-padding-left: 16px;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .wrapper-card {
-  margin-right: 12px;
   scroll-snap-align: start;
-  display: flex;
-  align-items: center;
+  width: 220px;
+  flex-shrink: 0;
 }
 
 .not-content-wrapper {

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -145,6 +145,7 @@ small {
 
 .wrapper-horizontal-list {
   display: flex;
+  width: 100%;
 }
 
 .wrapper-button {
@@ -152,7 +153,7 @@ small {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  padding: 10px 16px;
+  margin-bottom: 20px;
   justify-content: center;
 }
 

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -8,7 +8,7 @@
         </div>
         <div class="wrapper-horizontal-list">
           <ListingCardsHorizontal
-            :data="quizzesTeste"
+            :data="userQuizzesDisponiveis"
             notContentMesage="Você ainda não possui novas avaliações.
             Aguarde que logo estará disponível!"
           />

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -8,7 +8,7 @@
         </div>
         <div class="wrapper-horizontal-list">
           <ListingCardsHorizontal
-            :data="userQuizzesDisponiveis"
+            :data="quizzesTeste"
             notContentMesage="Você ainda não possui novas avaliações.
             Aguarde que logo estará disponível!"
           />
@@ -52,11 +52,6 @@ export default {
     ListingCardsHorizontal,
     ListingCardsVertical,
     BottomNavigationContainer
-  },
-  data () {
-    return {
-      notContentMesage: ''
-    }
   },
   computed: {
     ...mapGetters('quiz', {
@@ -153,7 +148,7 @@ small {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  margin-bottom: 20px;
+  margin-bottom: px;
   justify-content: center;
 }
 


### PR DESCRIPTION
# Ajustes na tela `Home`

## Responsáveis

@ericsonmoreira 

## Linked Issue

Close #64

## 📝 Descrição

Durante o desenvolvimento, parecia fazer sentido colocar uma propriedade `css` que mostra um reticencias (...) no título de um Card de Avaliação. Mas isso gera um problema na visualização completa do nome do `quiz`.

- Ajuste no título do card de avaliação. Não faz muito sentido usar o o ... no título dos cards de avaliação.

## 🖥 Passos a passo para teste

Descrever_o_passo_a_passo_para_testar_o_pr

1. Acessar uma página de card de avaliação
2. Mudar o título para verificar como sele se comporta
3. Verificar se ele está obedecendo os critérios de aceite

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
