### PR TITLE
Feature/i67 ajuste questao

### DIFF
--- a/src/components/BreadcrumbsQuestions.vue
+++ b/src/components/BreadcrumbsQuestions.vue
@@ -50,7 +50,7 @@ export default {
     display: flex;
     flex-wrap: nowrap;
     justify-content: center;
-    padding-top: 24px;
+    padding: 24px 8px 0 8px;
     width: 100%;
   }
   .breadcrumbs-item {

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="background">
+      <div id="quiz-name" class="roboto-bold">{{ quizName }}</div>
       <breadcrumbs-questions />
       <QuestionsList />
     </div>
@@ -18,6 +19,7 @@ export default {
   },
   computed: {
     ...mapGetters('quiz', {
+      quizName: 'getName',
       numberOfQuestions: 'getNumberOfQuestions',
       currentQuestion: 'getCurrentQuestion'
     })
@@ -30,5 +32,9 @@ export default {
     display: flex;
     flex-direction: column;
     height: 100vh;
+  }
+  #quiz-name{
+    font-size: 20px;
+    padding: 33px 16px 0 16px;
   }
 </style>

--- a/src/views/QuestionView.vue
+++ b/src/views/QuestionView.vue
@@ -1,8 +1,10 @@
 <template>
     <div class="background">
-      <div id="quiz-name" class="roboto-bold">{{ quizName }}</div>
-      <breadcrumbs-questions />
-      <QuestionsList />
+      <div id="fixed-header">
+        <div id="quiz-name" class="roboto-bold">{{quizName}}</div>
+        <breadcrumbs-questions />
+      </div>
+      <QuestionsList id="question-list"/>
     </div>
 </template>
 
@@ -35,6 +37,22 @@ export default {
   }
   #quiz-name{
     font-size: 20px;
-    padding: 33px 16px 0 16px;
+    padding: 24px 16px 0 16px;
+    height: 86px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+  #fixed-header{
+    position: fixed;
+    z-index: 9999;
+    background-color: #f5f5f5;
+    padding-bottom: 16px;
+    height: 130px;
+  }
+  #question-list{
+    margin-top: 130px;
   }
 </style>


### PR DESCRIPTION
# Adição do título da avaliação

## Responsáveis

@Laysacunha 

## Linked Issue

Close #67 

## 📝 Descrição

Foi observado que na versão 3 do MPV o título do quiz foi adicionado acima do breadcrumbs nas telas de avaliação.
O título e os breadcrumbs (header) devem permanecer fixos na tela e o conteúdo da questão rolar por trás desse cabeçalho.

## 🖥 Passos a passo para teste

1. Iniciar um quiz (pelo botão `INICIAR` das avaliações disponíveis ou `REVISAR` das avaliações concluídas
2. Observar header fixo e conteúdo deslizando por trás do header

## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x ] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x ] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
