### PR TITLE
💄 #66 - adicionado z-index em classe nav-wrapper

### DIFF
--- a/src/views/AllQuizzes.vue
+++ b/src/views/AllQuizzes.vue
@@ -87,6 +87,7 @@ export default {
     0px 1.85px 6.25px rgba(0, 0, 0, 0.19);
   border-radius: 0px 0px 16px 16px;
   overflow: hidden;
+  z-index: 9999;
 }
 
 .tab {


### PR DESCRIPTION
# Nome do PR

## Responsáveis

@JefersonNSoares 

## Linked Issue

Close #66 

## 📝 Descrição

Nos Cards de avaliações concluídas é exibido uma barra que mostra quantas questões o usuário acertou/errou. Entretanto, essa barra está se sobrepondo aos outros componentes da aplicação

## 🖥 Passos a passo para teste

1. Acessar a rota `/quizzes`
2. Simular a criação de varios cards
3. Ao rolar o scroll a barra de acertos não deve ficar sobreposta ao cabeçalho


## 📋 Checklist para criação do PR

- [ ] Testes foram implementados (novos ou não)
- [x] Issue foi definida no PR (Linked Issue na coluna à direita da página)
- [x] Pessoas contribuidoras foram definidas no PR (Assigners no PR)
